### PR TITLE
Use packaging system to determine whether or not BSD games are installed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,3 +150,8 @@ Zoom improved.
 
 Thanks to Eric W. Brown (@Feneric) for these contributions.
 
+**v3.13**
+
+Documentation added. 
+
+Bug fixes.

--- a/Documentation/BSDGames.html
+++ b/Documentation/BSDGames.html
@@ -35,6 +35,10 @@
           <dd><a href="https://en.wikipedia.org/wiki/Hunt_the_Wumpus">https://en.wikipedia.org/wiki/Hunt_the_Wumpus</a></dd>
           <dt>Wikipedia Entry for Tetris</dt>
           <dd><a href="https://en.wikipedia.org/wiki/Tetris">https://en.wikipedia.org/wiki/Tetris</a></dd>
+          <dt>Wikipedia Entry for Rogue</dt>
+          <dd><a href="https://en.wikipedia.org/wiki/Rogue_(video_game)">https://en.wikipedia.org/wiki/Rogue_(video_game)</a></dd>
+          <dt>Wikipedia Entry for Roguelike</dt>
+          <dd><a href="https://en.wikipedia.org/wiki/Roguelike">https://en.wikipedia.org/wiki/Roguelike</a></dd>
           <dt>Review of Several of the BSD Games</dt>
           <dd><a href="http://techtinkering.com/2009/08/11/my-top-10-classic-text-mode-bsd-games/">http://techtinkering.com/2009/08/11/my-top-10-classic-text-mode-bsd-games/</a></dd>
         </dl>
@@ -49,16 +53,17 @@
           <code>hack</code>, <code>hangman</code>, <code>hunt</code>, <code>mille</code>, <code>monop</code>,
           <code>morse</code>, <code>number</code>, <code>pig</code>, <code>phantasia</code>,
           <code>pom</code>, <code>ppt</code>, <code>primes</code>, <code>quiz</code>, <code>random</code>,
-          <code>rain</code>, <code>robots</code>, <code>rot13</code>, <code>sail</code>, <code>snake</code>,
-          <code>tetris</code>, <code>trek</code>, <code>wargames</code>, <code>worm</code>, <code>worms</code>,
-          <code>wump</code>, and <code>wtf</code>. Note that even though these are referred to as
-          &quot;games&quot;, some are actually text processors (for example, <code>morse</code> converts text
-          to Morse code, and <code>rot13</code> encodes and decodes using the ROT13 cipher) or math
+          <code>rain</code>, <code>robots</code>, <code>rogue</code>, <code>rot13</code>, <code>sail</code>,
+          <code>snake</code>, <code>tetris</code>, <code>trek</code>, <code>wargames</code>, <code>worm</code>,
+          <code>worms</code>, <code>wump</code>, and <code>wtf</code>. Note that even though these are referred
+          to as &quot;games&quot;, some are actually text processors (for example, <code>morse</code> converts
+          text to Morse code, and <code>rot13</code> encodes and decodes using the ROT13 cipher) or math
           utilities (for example, <code>primes</code> outputs ascending prime numbers, and <code>number</code>
           outputs the equivalent English text for a given number) or file utilities (for example,
           <code>random</code> outputs random lines from a file). Some of the games included are individually
           quite famous (for example <code>trek</code>, <code>wumpus</code>, <code>adventure</code>,
-          and <code>tetris</code>).
+          and <code>tetris</code>). The game <code>rogue</code> is the original source of the gaming
+          adjective &quot;roguelike&quot;.
         </p>
         <h2>PocketC.H.I.P. Considerations</h2>
         <p>

--- a/Installers/bsd.sh
+++ b/Installers/bsd.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-sudo apt-get install -y bsdgames
+sudo apt-get install -y bsdgames bsdgames-nonfree
 
 sudo mkdir /usr/games/bsdgames
 
 cd /usr/games
 
-sudo mv -t /usr/games/bsdgames adventure battlestar gomoku hangman monop phantasia robots snake tetris-bsd hunt arithmetic atc backgammon bcd boggle caesar canfield cfscores cribbage dab go-fish hack mille morse number pig pom ppt primes quiz rain random rot13 sail snscore teachgammon trek wargames worms wtf wump worm countmail
+sudo mv -t /usr/games/bsdgames adventure battlestar gomoku hangman monop phantasia robots snake tetris-bsd hunt arithmetic atc backgammon bcd boggle caesar canfield cfscores cribbage dab go-fish hack mille morse number pig pom ppt primes quiz rain random rot13 sail snscore teachgammon trek wargames worms wtf wump worm countmail rogue
 

--- a/Installers/bsd.sh
+++ b/Installers/bsd.sh
@@ -2,9 +2,3 @@
 
 sudo apt-get install -y bsdgames bsdgames-nonfree
 
-sudo mkdir /usr/games/bsdgames
-
-cd /usr/games
-
-sudo mv -t /usr/games/bsdgames adventure battlestar gomoku hangman monop phantasia robots snake tetris-bsd hunt arithmetic atc backgammon bcd boggle caesar canfield cfscores cribbage dab go-fish hack mille morse number pig pom ppt primes quiz rain random rot13 sail snscore teachgammon trek wargames worms wtf wump worm countmail rogue
-

--- a/PocketInstaller.sh
+++ b/PocketInstaller.sh
@@ -86,7 +86,7 @@ if hash zoom 2>/dev/null; then
 else
   P9="Zoom(Z-machine)|Installers/zoom.sh"
 fi
-if test -f /usr/games/adventure || test -f /usr/games/bsdgames/adventure; then
+if dpkg-query -s bsdgames &>> /dev/null; then
   :
 else
   P10="BSDgames|Installers/bsd.sh"

--- a/PocketInstaller.sh
+++ b/PocketInstaller.sh
@@ -129,7 +129,7 @@ fi
 if hash gargoyle-free 2>/dev/null; then
   : 
 else 
-  P18="Gargoyle|Installers/lectrote.sh"
+  P18="Gargoyle|Installers/gargoyle.sh"
 fi
 if hash lectrote 2>/dev/null; then
   : 


### PR DESCRIPTION
Switched the BSD games detection line to query the packaging system and moved the BSD games back to their typical location. Restored Rogue to the list of BSD games. Updated documentation as needed.