### PR TITLE
Made Ultima IV launcher work properly from PocketHome.

### DIFF
--- a/Launchers/xu4.sh
+++ b/Launchers/xu4.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-u4 -f
+#!/bin/sh
+vala-terminal -fs 8 -g 20 20 -e "/usr/local/bin/u4 -f;exit"
 


### PR DESCRIPTION
Running this directly never worked from PocketHome even though it worked from the shell. Here we're opening a shell to run it and exiting the shell immediately after the game exits in order to make it work.